### PR TITLE
Psiturk

### DIFF
--- a/overcooked-demo/server/app.py
+++ b/overcooked-demo/server/app.py
@@ -28,6 +28,9 @@ MAX_GAMES = CONFIG['MAX_GAMES']
 # Frames per second cap for serving to client
 MAX_FPS = CONFIG['MAX_FPS']
 
+# Default configuration for psiturk experiment
+PSITURK_CONFIG = json.dumps(CONFIG['psiturk'])
+
 # Global queue of available IDs. This is how we synch game creation and keep track of how many games are in memory
 FREE_IDS = queue.Queue(maxsize=MAX_GAMES)
 
@@ -277,7 +280,8 @@ def index():
 @app.route('/psiturk')
 def psiturk():
     uid = request.args.get("UID")
-    return render_template('psiturk.html', uid=uid)
+    psiturk_config = request.args.get('config', PSITURK_CONFIG)
+    return render_template('psiturk.html', uid=uid, config=psiturk_config)
 
 @app.route('/instructions')
 def instructions():

--- a/overcooked-demo/server/app.py
+++ b/overcooked-demo/server/app.py
@@ -289,7 +289,6 @@ def instructions():
 
 @app.route('/debug')
 def debug():
-    # TODO: Figure out if it is worth it to make this entire endpoint atomic
     resp = {}
     games = []
     active_games = []

--- a/overcooked-demo/server/config.json
+++ b/overcooked-demo/server/config.json
@@ -1,5 +1,13 @@
 {
     "layouts" : ["cramped_room", "cramped_room_tomato", "asymmetric_advantages", "coordination_ring", "forced_coordination", "counter_circuit"],
     "MAX_GAMES" : 10,
-    "MAX_FPS" : 30
+    "MAX_FPS" : 30,
+    "psiturk" : {
+        "experimentParams" : {
+            "layouts" : ["counter_circuit", "cramped_room"],
+            "gameTime" : 11,
+            "playerZero" : "DummyAI"
+        },
+        "lobbyWaitTime" : 300000
+    }
 }

--- a/overcooked-demo/server/game.py
+++ b/overcooked-demo/server/game.py
@@ -447,12 +447,9 @@ class OvercookedGame(Game):
             "score" : self.score,
             "time_elapsed" : time() - self.start_time,
             "cur_gameloop" : self.curr_tick,
-            "client_id" : None,
-            "is_leader" : True,
-            "partner_id" : None,
-            "datetime" : None,
             "layout" : self.mdp.terrain_mtx,
-            "layout_name" : self.curr_layout
+            "layout_name" : self.curr_layout,
+            "trial_id" : self.trial_id
         }
         self.trajectory.append(transition)
         
@@ -462,10 +459,12 @@ class OvercookedGame(Game):
         super(OvercookedGame, self).enqueue_action(player_id, overcooked_action)
 
     def reset(self):
+        print("curr layout before reset", self.curr_layout, flush=True)
         status = super(OvercookedGame, self).reset()
         if status == self.Status.RESET:
             # Hacky way of making sure game timer doesn't "start" until after reset timeout has passed
             self.start_time += self.reset_timeout / 1000
+        print("curr layout after reset", self.curr_layout, flush=True)
 
 
     def tick(self):
@@ -480,6 +479,7 @@ class OvercookedGame(Game):
         self.start_time = time()
         self.score = 0
         self.threads = []
+        self.trial_id = self.psiturk_uid + str(self.start_time)
         for npc_policy in self.npc_policies:
             self.npc_state_queues[npc_policy].put(self.state)
             t = Thread(target=self.npc_policy_consumer, args=(npc_policy,))
@@ -522,7 +522,7 @@ class OvercookedGame(Game):
         """
         Returns and then clears the accumulated trajectory
         """
-        data = { "uid" : self.psiturk_uid  + "_" + self.curr_layout, "trajectory" : self.trajectory }
+        data = { "uid" : self.psiturk_uid  + "_" + str(time()), "trajectory" : self.trajectory }
         self.trajectory = []
         return data
 

--- a/overcooked-demo/server/game.py
+++ b/overcooked-demo/server/game.py
@@ -459,12 +459,10 @@ class OvercookedGame(Game):
         super(OvercookedGame, self).enqueue_action(player_id, overcooked_action)
 
     def reset(self):
-        print("curr layout before reset", self.curr_layout, flush=True)
         status = super(OvercookedGame, self).reset()
         if status == self.Status.RESET:
             # Hacky way of making sure game timer doesn't "start" until after reset timeout has passed
             self.start_time += self.reset_timeout / 1000
-        print("curr layout after reset", self.curr_layout, flush=True)
 
 
     def tick(self):

--- a/overcooked-demo/server/game.py
+++ b/overcooked-demo/server/game.py
@@ -522,7 +522,7 @@ class OvercookedGame(Game):
         """
         Returns and then clears the accumulated trajectory
         """
-        data = { "uid" : self.psiturk_uid, "trajectory" : self.trajectory }
+        data = { "uid" : self.psiturk_uid  + "_" + self.curr_layout, "trajectory" : self.trajectory }
         self.trajectory = []
         return data
 

--- a/overcooked-demo/server/graphics/overcooked_graphics_v1.js
+++ b/overcooked-demo/server/graphics/overcooked_graphics_v1.js
@@ -85,7 +85,7 @@ class OvercookedScene extends Phaser.Scene {
     set_state(state) {
         this.state = state.state;
         this.score = state.score;
-        this.time = Math.ceil(state.time_left);
+        this.time = Math.round(state.time_left);
     }
 
     preload() {

--- a/overcooked-demo/server/graphics/overcooked_graphics_v2.js
+++ b/overcooked-demo/server/graphics/overcooked_graphics_v2.js
@@ -85,7 +85,7 @@ class OvercookedScene extends Phaser.Scene {
     set_state(state) {
         this.state = state.state;
         this.score = state.score;
-        this.time = Math.ceil(state.time_left);
+        this.time = Math.round(state.time_left);
     }
 
     preload() {

--- a/overcooked-demo/server/static/js/index.js
+++ b/overcooked-demo/server/static/js/index.js
@@ -1,0 +1,192 @@
+// Persistent network connection that will be used to transmit real-time data
+var socket = io();
+
+/* * * * * * * * * * * * * * * * 
+ * Button click event handlers *
+ * * * * * * * * * * * * * * * */
+
+$(function() {
+    $('#create').click(function () {
+        params = arrToJSON($('form').serializeArray());
+        params.layouts = [params.layout]
+        data = {
+            "params" : params
+        };
+        socket.emit("create", data);
+    });
+});
+
+$(function() {
+    $('#join').click(function() {
+        socket.emit("join", {});
+    });
+});
+
+$(function() {
+    $('#leave').click(function() {
+        socket.emit('leave', {});
+    });
+});
+
+
+
+
+
+/* * * * * * * * * * * * * 
+ * Socket event handlers *
+ * * * * * * * * * * * * */
+
+window.intervalID = -1;
+
+socket.on('waiting', function(data) {
+    // Show game lobby
+    $('#game-over').hide();
+    $('#instructions').hide();
+    $("#overcooked").empty();
+    $('#lobby').show();
+    $('#join').hide();
+    $('#create').hide();
+    $('#leave').show();
+    if (window.intervalID === -1) {
+        window.intervalID = setInterval(function() {
+            socket.emit('join', {});
+        }, 1000);
+    }
+});
+
+socket.on('creation_failed', function(data) {
+    // Tell user what went wrong
+    let err = data['error']
+    $("#overcooked").empty();
+    $('#overcooked').append(`<h4>Sorry, game creation code failed with error: ${JSON.stringify(err)}</>`);
+});
+
+socket.on('start_game', function(data) {
+    // Hide game-over and lobby, show game title header
+    if (window.intervalID !== -1) {
+        clearInterval(window.intervalID);
+        window.intervalID = -1;
+    }
+    graphics_config = {
+        container_id : "overcooked",
+        start_info : data
+    };
+    $("#overcooked").empty();
+    $('#game-over').hide();
+    $('#lobby').hide();
+    $('#join').hide();
+    $('#create').hide();
+    $("#instructions").hide();
+    $('#leave').show();
+    $('#game-title').show();
+    enable_key_listener();
+    graphics_start(graphics_config);
+});
+
+socket.on('reset_game', function(data) {
+    graphics_end();
+    disable_key_listener();
+    $("overcooked").empty();
+    $("#reset-game").show();
+    setTimeout(function() {
+        $("reset-game").hide();
+        graphics_config = {
+            container_id : "overcooked",
+            start_info : data.state
+        };
+        graphics_start(graphics_config);
+        enable_key_listener();
+    }, data.timeout);
+});
+
+socket.on('state_pong', function(data) {
+    // Draw state update
+    drawState(data['state']);
+});
+
+socket.on('end_game', function(data) {
+    // Hide game data and display game-over html
+    graphics_end();
+    disable_key_listener();
+    $('#game-title').hide();
+    $('#game-over').show();
+    $("#join").show();
+    $("#create").show();
+    $("#instructions").show();
+    $("#leave").hide();
+    
+    // Game ended unexpectedly
+    if (data.status === 'inactive') {
+        $('#error-exit').show();
+    }
+});
+
+socket.on('end_lobby', function() {
+    // Hide lobby
+    $('#lobby').hide();
+    $("#join").show();
+    $("#create").show();
+    $("#leave").hide();
+    $("#instructions").hide();
+
+    // Stop trying to join
+    clearInterval(window.intervalID);
+    window.intervalID = -1;
+})
+
+
+/* * * * * * * * * * * * * * 
+ * Game Key Event Listener *
+ * * * * * * * * * * * * * */
+
+function enable_key_listener() {
+    $(document).on('keydown', function(e) {
+        let action = 'STAY'
+        switch (e.which) {
+            case 37: // left
+                action = 'LEFT';
+                break;
+
+            case 38: // up
+                action = 'UP';
+                break;
+
+            case 39: // right
+                action = 'RIGHT';
+                break;
+
+            case 40: // down
+                action = 'DOWN';
+                break;
+
+            case 32: //space
+                action = 'SPACE';
+                break;
+
+            default: // exit this handler for other keys
+                return; 
+        }
+        e.preventDefault();
+        socket.emit('action', { 'action' : action });
+    });
+};
+
+function disable_key_listener() {
+    $(document).off('keydown');
+};
+
+
+/* * * * * * * * * * *
+ * Utility Functions *
+ * * * * * * * * * * */
+
+var arrToJSON = function(arr) {
+    let retval = {}
+    for (let i = 0; i < arr.length; i++) {
+        elem = arr[i];
+        key = elem['name'];
+        value = elem['value'];
+        retval[key] = value;
+    }
+    return retval;
+};

--- a/overcooked-demo/server/static/js/psiturk.js
+++ b/overcooked-demo/server/static/js/psiturk.js
@@ -89,7 +89,7 @@ socket.on('reset_game', function(data) {
 
         // Propogate game stats to parent window (psiturk)
         console.log("sending message");
-        window.top.postMessage({ name : "data", data : [{"field_1" : "val_11", "field_2" : "val_21"}, {"field_1" : "val_12", "field_2" : "val_22"}], done : false}, "*");
+        window.top.postMessage({ name : "data", data : data.data, done : false}, "*");
     }, data.timeout);
 });
 
@@ -114,7 +114,7 @@ socket.on('end_game', function(data) {
 
     // Propogate game stats to parent window with psiturk code
     console.log("sending final message");
-    window.top.postMessage({ name : "data", data : [{"field_1" : "val_final", "field_2" : "val_2_final"}], done : true }, "*");
+    window.top.postMessage({ name : "data", data : data.data, done : true }, "*");
 });
 
 socket.on('end_lobby', function() {
@@ -181,8 +181,11 @@ function disable_key_listener() {
  * * * * * * * * * * * */
 
 socket.on("connect", function() {
+    let uid = $('#uid').text();
+    let params = JSON.parse(JSON.stringify(experimentParams));
+    params.psiturk_uid = uid;
     let data = {
-        "params" : experimentParams
+        "params" : params
     };
     socket.emit("join", data);
 });

--- a/overcooked-demo/server/static/js/psiturk.js
+++ b/overcooked-demo/server/static/js/psiturk.js
@@ -48,7 +48,6 @@ socket.on('creation_failed', function(data) {
     $("error-exit").show();
 
     // Let parent window (psiturk) know error occurred
-    console.log("sending message");
     window.top.postMessage({ name : "error"}, "*");
 });
 
@@ -88,7 +87,6 @@ socket.on('reset_game', function(data) {
         enable_key_listener();
 
         // Propogate game stats to parent window (psiturk)
-        console.log("sending message");
         window.top.postMessage({ name : "data", data : data.data, done : false}, "*");
     }, data.timeout);
 });
@@ -113,7 +111,6 @@ socket.on('end_game', function(data) {
     }
 
     // Propogate game stats to parent window with psiturk code
-    console.log("sending final message");
     window.top.postMessage({ name : "data", data : data.data, done : true }, "*");
 });
 
@@ -130,7 +127,6 @@ socket.on('end_lobby', function() {
     window.intervalID = -1;
 
     // Let parent window (psiturk) know what happened
-    console.log("sending message");
     window.top.postMessage({ name : "timeout" }, "*");
 })
 

--- a/overcooked-demo/server/static/js/psiturk.js
+++ b/overcooked-demo/server/static/js/psiturk.js
@@ -2,6 +2,7 @@
 var socket = io();
 
 // TODO: figure out how to move these params server side
+var config;
 var experimentParams = {
     layouts : ["cramped_room", "counter_circuit"],
     gameTime : 10,
@@ -36,7 +37,7 @@ socket.on('waiting', function(data) {
         // Timeout to leave lobby if no-one is found
         window.lobbyTimeout = setTimeout(function() {
             socket.emit('leave', {});
-        }, lobbyWaitTime)
+        }, config.lobbyWaitTime)
     }
 });
 
@@ -177,12 +178,18 @@ function disable_key_listener() {
  * * * * * * * * * * * */
 
 socket.on("connect", function() {
+    // set configuration variables
+    set_config();
+
+    // Config for this specific game
     let uid = $('#uid').text();
-    let params = JSON.parse(JSON.stringify(experimentParams));
+    let params = JSON.parse(JSON.stringify(config.experimentParams));
     params.psiturk_uid = uid;
     let data = {
         "params" : params
     };
+
+    // create (or join if it exists) new game
     socket.emit("join", data);
 });
 
@@ -201,3 +208,7 @@ var arrToJSON = function(arr) {
     }
     return retval;
 };
+
+var set_config = function() {
+    config = JSON.parse($("#config").text());
+}

--- a/overcooked-demo/server/static/js/psiturk.js
+++ b/overcooked-demo/server/static/js/psiturk.js
@@ -1,7 +1,6 @@
 // Persistent network connection that will be used to transmit real-time data
 var socket = io();
 
-// TODO: figure out how to move these params server side
 var config;
 var experimentParams = {
     layouts : ["cramped_room", "counter_circuit"],

--- a/overcooked-demo/server/static/templates/index.html
+++ b/overcooked-demo/server/static/templates/index.html
@@ -20,7 +20,7 @@
 
     <script src="static/js/graphics.js", type="text/javascript"></script>
     <!-- <script src="static/js/dummy_graphics.js", type="text/javascript"></script> -->
-    <script src="static/js/main.js" type="text/javascript"></script>
+    <script src="static/js/index.js" type="text/javascript"></script>
 
     <link rel="stylesheet" href="static/css/bootstrap.min.css" type="text/css" />
     <link rel="stylesheet" href="static/css/style.css" type="text/css" />
@@ -59,19 +59,11 @@
     <label for="gameTime">Game Length (sec)</label>
     <input type="number" id="gameTime" value="30" min="1" max="1800" name="gameTime">
   </div>
-  <!-- <div class="form-group col-lg-2">
-    <label for="layout">Deterministic?</label>
-    <input type="checkbox" id="deterministic" name="deterministic">
-  </div> -->
-  <!-- <div class="form-group col-lg-2">
-    <label for="layout">Automatically Save Game Trajectories?</label>
-    <input type="checkbox" id="saveTrajectories" name="saveTrajectories">
-  </div> -->
   
       </div>
       </div>
     </form>
-    <h4 class="text-center"><a href="./instructions">Instructions</a></h4>
+    <h4 id="instructions" class="text-center"><a href="./instructions">Instructions</a></h4>
     <div id="lobby", class="text-center" style="display:none">
         <h4 class="text-center">Game Lobby</h4>
         Waiting for game to start...
@@ -80,6 +72,7 @@
         <h4 id="game-title" style="display:none">Game in Progress</h4>
         <h4 id="game-over" style="display:none">Game Over</h4>
         <div id="overcooked"></div>
+        <div id="error-exit" sytyle="display:none">Game ended unexpectedly (probably due to another user disconnecting)</div>
     </div>
     <div id="control" class="text-center">
         <button id="create">Create Game</button>

--- a/overcooked-demo/server/static/templates/psiturk.html
+++ b/overcooked-demo/server/static/templates/psiturk.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+
+    <title>Psiturk Experiment</title>
+    <link rel="Favicon" href="static/favicon.ico" />
+
+    <script src="static/lib/jquery-min.js" type="text/javascript"> </script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/phaser@3.23.0/dist/phaser.min.js"></script>
+
+    <script src="static/js/graphics.js", type="text/javascript"></script>
+    <script src="static/js/psiturk.js" type="text/javascript"></script>
+
+    <link rel="stylesheet" href="static/css/bootstrap.min.css" type="text/css" />
+    <link rel="stylesheet" href="static/css/style.css" type="text/css" />
+  </head>
+  <body>
+    <div id="overcooked-container" class="text-center">
+        <h4 id="game-title" style="display:none">Game in Progress</h4>
+        <h4 id="game-over" style="display:none">Game Over</h4>
+        <div id="overcooked"></div>
+        <div id="error" style="display:none">Game ended unexpectedly (probably due to other user disconnecting)</div>
+        <div id="reset-game", class="text-center" style="display:none">
+            Waiting for next round to start...
+        </div>  
+    </div>
+
+    <div id="lobby", class="text-center" style="display:none">
+        <h2>Waiting Room</h2>
+        <div id="finding_partner">
+            <p>Great! Now you will play with another Mturker. You will receive a compensation bonus for each apple you deliver in this match.</p>
+            <p>Please wait while we find you a partner (this will take at most 5 minutes). You will receive full compensation if we fail to find one. </p> 
+            <p>Searching <span id="ellipses">...</span></p>
+        </div>
+        <div id="error-exit" style="display:none">"You will be redirected to the end of the HIT and receive base payment in 5 seconds."</div>
+    </div>
+    
+
+    <noscript>
+      <h1>Warning: Javascript seems to be disabled</h1>
+      <p>This website requires that Javascript be enabled on your browser.</p>
+      <p>Instructions for enabling Javascript in your browser can be found 
+	<a href="http://support.google.com/bin/answer.py?hl=en&answer=23852">here</a></p>
+    </noscript>
+  </body>
+</html>

--- a/overcooked-demo/server/static/templates/psiturk.html
+++ b/overcooked-demo/server/static/templates/psiturk.html
@@ -23,6 +23,7 @@
   </head>
   <body>
     <div id="uid" style="display:none;">{{uid}}</div>
+    <div id="config" style="display:none;">{{config}}</div>
     <div id="overcooked-container" class="text-center">
         <h4 id="game-title" style="display:none">Game in Progress</h4>
         <h4 id="game-over" style="display:none">Game Over</h4>

--- a/overcooked-demo/server/static/templates/psiturk.html
+++ b/overcooked-demo/server/static/templates/psiturk.html
@@ -22,6 +22,7 @@
     <link rel="stylesheet" href="static/css/style.css" type="text/css" />
   </head>
   <body>
+    <div id="uid" style="display:none;">{{uid}}</div>
     <div id="overcooked-container" class="text-center">
         <h4 id="game-title" style="display:none">Game in Progress</h4>
         <h4 id="game-over" style="display:none">Game Over</h4>


### PR DESCRIPTION
Added psiturk experiment functionality

# game.py
* Added ability to `reset` game 
* Abstractly, `reset` occurs on a call to `tick` when `needs_reset` returns True
* Concretely, a `reset` happens at the end of every layout, in order to setup a new Overcooked MDP
* Added `Game.Status` enum
    * Before, games had two states, `active` and `inactive` so it could be controlled by a boolean
    * Now, games can be `inactive`, `active`, `in_play`, `in_reset` or `done`

## app.py
* Added `/psiturk` route to app

## psiturk.js
* Base functionality similar to `index.js`
* On game document load, creates a game specified by `config.psiturk.exerimentParams`
* On game reset, sends `postMessage` to parent window
    * this is how overcooked-demo communicates with psiturk client code
* On game end, sends `postMessage` with trajectory data and done=True flag

## config.json
* Added `psiturk` key which controls all psiturk configuration
* Includes experiment configurations (such as layouts and game times) 
* Also includes  `lobbyWaitTime`, the number of milliseconds after which we end the HIT if a psiturk worker was unable to be paired with a partner