### PR TITLE
Visualize potential

### DIFF
--- a/overcooked-demo/docker-compose.yml
+++ b/overcooked-demo/docker-compose.yml
@@ -8,7 +8,7 @@ services:
                 BUILD_ENV: "${BUILD_ENV:-production}"
                 OVERCOOKED_BRANCH: "${OVERCOOKED_BRANCH:-master}"
                 HARL_BRANCH: "${HARL_BRANCH:-rllib}"
-                GRAPHICS: "${GRAPHICS:-overcooked_graphics_v2.1.js}"
+                GRAPHICS: "${GRAPHICS:-overcooked_graphics_v2.2.js}"
         environment: 
             FLASK_ENV: "${BUILD_ENV:-production}"
         ports:

--- a/overcooked-demo/docker-compose.yml
+++ b/overcooked-demo/docker-compose.yml
@@ -7,6 +7,7 @@ services:
             args:
                 BUILD_ENV: "${BUILD_ENV:-production}"
                 OVERCOOKED_BRANCH: "${OVERCOOKED_BRANCH:-master}"
+                HARL_BRANCH: "${HARL_BRANCH:-rllib}"
                 GRAPHICS: "${GRAPHICS:-overcooked_graphics_v2.1.js}"
         environment: 
             FLASK_ENV: "${BUILD_ENV:-production}"

--- a/overcooked-demo/server/Dockerfile
+++ b/overcooked-demo/server/Dockerfile
@@ -2,20 +2,40 @@ FROM python:3.7-stretch
 
 ARG BUILD_ENV
 ARG OVERCOOKED_BRANCH
+ARG HARL_BRANCH
 ARG GRAPHICS
 
 WORKDIR /app
+
+# Install non-chai dependencies
 COPY ./requirements.txt ./requirements.txt
 RUN pip install -r requirements.txt
+
+# Install eventlet production server if production build
 RUN if [ "$BUILD_ENV" = "production" ] ; then pip install eventlet ; fi
+
+# Clone chai code
 RUN git clone https://github.com/HumanCompatibleAI/overcooked_ai.git --branch $OVERCOOKED_BRANCH --single-branch /overcooked_ai
+RUN git clone https://github.com/HumanCompatibleAI/human_aware_rl.git --branch $HARL_BRANCH --single-branch /human_aware_rl
+
+# Dummy data_dir so things don't break
+RUN echo "import os; DATA_DIR=os.path.abspath('.')" >> /human_aware_rl/human_aware_rl/data_dir.py
+
+# Install chai dependencies
 RUN pip install -e /overcooked_ai
+RUN pip install -e /human_aware_rl
+
+# Copy over remaining files
 COPY ./static ./static
 COPY ./*.py ./
 COPY ./graphics/$GRAPHICS ./static/js/graphics.js
 COPY ./config.json ./config.json
+
+# Set environment variables that will be used by app.py
 ENV HOST 0.0.0.0
 ENV PORT 5000
 ENV CONF_PATH config.json
+
+# Do the thing
 EXPOSE 5000
 CMD ["python", "-u", "app.py"]

--- a/overcooked-demo/server/app.py
+++ b/overcooked-demo/server/app.py
@@ -10,7 +10,8 @@ import pickle, queue, atexit, json, logging
 from utils import ThreadSafeSet, ThreadSafeDict
 from flask import Flask, render_template, jsonify, request
 from flask_socketio import SocketIO, join_room, leave_room, emit
-from game import OvercookedGame, OvercookedTutorial, Game, AGENT_DIR
+from game import OvercookedGame, OvercookedTutorial, Game
+import game
 
 
 ### Thoughts -- where I'll log potential issues/ideas as they come up
@@ -32,6 +33,12 @@ LOGFILE = CONFIG['logfile']
 
 # Available layout names
 LAYOUTS = CONFIG['layouts']
+
+# Maximum allowable game length (in seconds)
+MAX_GAME_LENGTH = CONFIG['MAX_GAME_LENGTH']
+
+# Path to where pre-trained agents will be stored on server
+AGENT_DIR = CONFIG['AGENT_DIR']
 
 # Maximum number of games that can run concurrently. Contrained by available memory and CPU
 MAX_GAMES = CONFIG['MAX_GAMES']
@@ -74,6 +81,8 @@ GAME_NAME_TO_CLS = {
     "overcooked" : OvercookedGame,
     "tutorial" : OvercookedTutorial
 }
+
+game._configure(MAX_GAME_LENGTH, AGENT_DIR)
 
 
 

--- a/overcooked-demo/server/config.json
+++ b/overcooked-demo/server/config.json
@@ -1,6 +1,6 @@
 {
     "logfile" : "app.log",
-    "layouts" : ["cramped_room", "cramped_room_tomato", "asymmetric_advantages", "coordination_ring", "forced_coordination", "counter_circuit", "cramped_corridor", "marshmallow_experiment", "long_cook_time", "forced_coordination_tomato", "asymmetric_advantages_tomato", "marshmallow_experiment_coordination", "pipeline"],
+    "layouts" : ["cramped_room", "cramped_room_tomato", "asymmetric_advantages", "coordination_ring", "forced_coordination", "counter_circuit", "cramped_corridor", "marshmallow_experiment", "long_cook_time", "forced_coordination_tomato", "asymmetric_advantages_tomato", "marshmallow_experiment_coordination", "pipeline", "you_shall_not_pass"],
     "MAX_GAMES" : 10,
     "MAX_GAME_LENGTH" : 120,
     "AGENT_DIR" : "./static/assets/agents",

--- a/overcooked-demo/server/config.json
+++ b/overcooked-demo/server/config.json
@@ -2,6 +2,8 @@
     "logfile" : "app.log",
     "layouts" : ["cramped_room", "cramped_room_tomato", "asymmetric_advantages", "coordination_ring", "forced_coordination", "counter_circuit", "cramped_corridor", "marshmallow_experiment", "long_cook_time", "forced_coordination_tomato", "asymmetric_advantages_tomato", "marshmallow_experiment_coordination", "pipeline"],
     "MAX_GAMES" : 10,
+    "MAX_GAME_LENGTH" : 120,
+    "AGENT_DIR" : "./static/assets/agents",
     "MAX_FPS" : 30,
     "psiturk" : {
         "experimentParams" : {

--- a/overcooked-demo/server/game.py
+++ b/overcooked-demo/server/game.py
@@ -173,7 +173,8 @@ class Game(ABC):
             # Could run into issues with is_active not being thread safe
             return
         if player_id not in self.players:
-            raise ValueError("Invalid player ID")
+            # Only players actively in game are allowed to enqueue actions
+            return
         try:
             player_idx = self.players.index(player_id)
             self.pending_actions[player_idx].put(action)
@@ -381,8 +382,8 @@ class OvercookedGame(Game):
             self.npc_policies[player_one_id] = self.get_policy(playerOne)
             self.npc_state_queues[player_one_id] = LifoQueue()
 
-        if len(self.npc_policies) == self.max_players:
-            raise ValueError("At least one player must be a human")
+        # if len(self.npc_policies) == self.max_players:
+        #     raise ValueError("At least one player must be a human")
 
     def _curr_game_over(self):
         return time() - self.start_time >= self.max_time

--- a/overcooked-demo/server/graphics/overcooked_graphics_v2.2.js
+++ b/overcooked-demo/server/graphics/overcooked_graphics_v2.2.js
@@ -1,0 +1,496 @@
+/*
+
+Added state potential to HUD
+
+*/
+
+
+
+// How long a graphics update should take in milliseconds
+// Note that the server updates at 30 fps
+var ANIMATION_DURATION = 50;
+
+var DIRECTION_TO_NAME = {
+    '0,-1': 'NORTH',
+    '0,1': 'SOUTH',
+    '1,0': 'EAST',
+    '-1,0': 'WEST'
+};
+
+var scene_config = {
+    player_colors : {0: 'blue', 1: 'green'},
+    tileSize : 80,
+    animation_duration : ANIMATION_DURATION,
+    show_post_cook_time : false,
+    cook_time : 20,
+    assets_loc : "./static/assets/",
+    hud_size : 150
+};
+
+var game_config = {
+    type: Phaser.WEBGL,
+    pixelArt: true,
+    audio: {
+        noAudio: true
+    }
+};
+
+var graphics;
+
+// Invoked at every state_pong event from server
+function drawState(state) {
+    // Try catch necessary because state pongs can arrive before graphics manager has finished initializing
+    try {
+        graphics.set_state(state);
+    } catch {
+        console.log("error updating state");
+    }
+};
+
+// Invoked at 'start_game' event
+function graphics_start(graphics_config) {
+    graphics = new GraphicsManager(game_config, scene_config, graphics_config);
+};
+
+// Invoked at 'end_game' event
+function graphics_end() {
+    graphics.game.renderer.destroy();
+    graphics.game.loop.stop();
+    graphics.game.destroy();
+}
+
+class GraphicsManager {
+    constructor(game_config, scene_config, graphics_config) {
+        let start_info = graphics_config.start_info;
+        scene_config.terrain = start_info.terrain;
+        scene_config.start_state = start_info.state;
+        game_config.scene = new OvercookedScene(scene_config);
+        game_config.width = scene_config.tileSize*scene_config.terrain[0].length;
+        game_config.height = scene_config.tileSize*scene_config.terrain.length  + scene_config.hud_size;
+        game_config.parent = graphics_config.container_id;
+        this.game = new Phaser.Game(game_config);
+    }
+
+    set_state(state) {
+        this.game.scene.getScene('PlayGame').set_state(state);
+    }
+}
+
+class OvercookedScene extends Phaser.Scene {
+    constructor(config) {
+        super({key: "PlayGame"});
+        this.state = config.start_state.state;
+        this.player_colors = config.player_colors;
+        this.terrain = config.terrain;
+        this.tileSize = config.tileSize;
+        this.animation_duration = config.animation_duration;
+        this.show_post_cook_time = config.show_post_cook_time;
+        this.cook_time = config.cook_time;
+        this.assets_loc = config.assets_loc;
+        this.hud_size = config.hud_size
+        this.hud_data = {
+            potential : config.start_state.potential,
+            score : config.start_state.score,
+            time : config.start_state.time_left,
+            bonus_orders : config.start_state.state.bonus_orders,
+            all_orders : config.start_state.state.all_orders
+        }
+    }
+
+    set_state(state) {
+        this.hud_data.potential = state.potential;
+        this.hud_data.score = state.score;
+        this.hud_data.time = Math.round(state.time_left);
+        this.hud_data.bonus_orders = state.state.bonus_orders;
+        this.hud_data.all_orders = state.state.all_orders;
+        this.state = state.state;
+    }
+
+    preload() {
+        this.load.atlas("tiles",
+            this.assets_loc + "terrain.png",
+            this.assets_loc + "terrain.json");
+        this.load.atlas("chefs",
+            this.assets_loc + "chefs.png",
+            this.assets_loc + "chefs.json");
+        this.load.atlas("objects",
+            this.assets_loc + "objects.png",
+            this.assets_loc + "objects.json");
+        this.load.multiatlas("soups",
+            this.assets_loc + "soups.json",
+            this.assets_loc)
+    }
+
+    create() {
+        this.sprites = {};
+        this.drawLevel();
+        this._drawState(this.state, this.sprites);
+    }
+
+    update() {
+        if (typeof(this.state) !== 'undefined') {
+            this._drawState(this.state, this.sprites);
+        }
+        if (typeof(this.hud_data) !== 'undefined') {
+            let { width, height } = this.game.canvas;
+            let board_height = height - this.hud_size;
+            this._drawHUD(this.hud_data, this.sprites, board_height);
+        }
+    }
+    drawLevel() {
+        // Fill canvas with white
+        this.cameras.main.setBackgroundColor('#e6b453')
+
+        //draw tiles
+        let terrain_to_img = {
+            ' ': 'floor.png',
+            'X': 'counter.png',
+            'P': 'pot.png',
+            'O': 'onions.png',
+            'T': 'tomatoes.png',
+            'D': 'dishes.png',
+            'S': 'serve.png'
+        };
+        let pos_dict = this.terrain;
+        for (let row in pos_dict) {
+            if (!pos_dict.hasOwnProperty(row)) {continue}
+            for (let col = 0; col < pos_dict[row].length; col++) {
+                let [x, y] = [col, row]
+                let ttype = pos_dict[row][col];
+                let tile = this.add.sprite(
+                    this.tileSize * x,
+                    this.tileSize * y,
+                    "tiles",
+                    terrain_to_img[ttype]
+                );
+                tile.setDisplaySize(this.tileSize, this.tileSize);
+                tile.setOrigin(0);
+            }
+        }
+    }
+    _drawState (state, sprites) {
+        sprites = typeof(sprites) === 'undefined' ? {} : sprites;
+
+        //draw chefs
+        sprites['chefs'] =
+            typeof(sprites['chefs']) === 'undefined' ? {} : sprites['chefs'];
+        for (let pi = 0; pi < state.players.length; pi++) {
+            let chef = state.players[pi];
+            let [x, y] = chef.position;
+            let dir = DIRECTION_TO_NAME[chef.orientation];
+            let held_obj = chef.held_object;
+            if (typeof(held_obj) !== 'undefined' && held_obj !== null) {
+                if (held_obj.name === 'soup') {
+                    let ingredients = held_obj._ingredients.map(x => x['name']);
+                    if (ingredients.includes('onion')) {
+                        held_obj = "-soup-onion";
+                    } else {
+                        held_obj = "-soup-tomato";
+                    }
+                    
+                }
+                else {
+                    held_obj = "-"+held_obj.name;
+                }
+            }
+            else {
+                held_obj = "";
+            }
+            if (typeof(sprites['chefs'][pi]) === 'undefined') {
+                let chefsprite = this.add.sprite(
+                    this.tileSize*x,
+                    this.tileSize*y,
+                    "chefs",
+                    `${dir}${held_obj}.png`
+                );
+                chefsprite.setDisplaySize(this.tileSize, this.tileSize);
+                chefsprite.depth = 1;
+                chefsprite.setOrigin(0);
+                let hatsprite = this.add.sprite(
+                    this.tileSize*x,
+                    this.tileSize*y,
+                    "chefs",
+                    `${dir}-${this.player_colors[pi]}hat.png`
+                );
+                hatsprite.setDisplaySize(this.tileSize, this.tileSize);
+                hatsprite.depth = 2;
+                hatsprite.setOrigin(0);
+                sprites['chefs'][pi] = {chefsprite, hatsprite};
+            }
+            else {
+                let chefsprite = sprites['chefs'][pi]['chefsprite'];
+                let hatsprite = sprites['chefs'][pi]['hatsprite'];
+                chefsprite.setFrame(`${dir}${held_obj}.png`);
+                hatsprite.setFrame(`${dir}-${this.player_colors[pi]}hat.png`);
+                this.tweens.add({
+                    targets: [chefsprite, hatsprite],
+                    x: this.tileSize*x,
+                    y: this.tileSize*y,
+                    duration: this.animation_duration,
+                    ease: 'Linear',
+                    onComplete: (tween, target, player) => {
+                        target[0].setPosition(this.tileSize*x, this.tileSize*y);
+                        //this.animating = false;
+                    }
+                })
+            }
+        }
+
+        //draw environment objects
+        if (typeof(sprites['objects']) !== 'undefined') {
+            for (let objpos in sprites.objects) {
+                let {objsprite, timesprite} = sprites.objects[objpos];
+                objsprite.destroy();
+                if (typeof(timesprite) !== 'undefined') {
+                    timesprite.destroy();
+                }
+            }
+        }
+        sprites['objects'] = {};
+
+        for (let objpos in state.objects) {
+            if (!state.objects.hasOwnProperty(objpos)) { continue }
+            let obj = state.objects[objpos];
+            let [x, y] = obj.position;
+            let terrain_type = this.terrain[y][x];
+            let spriteframe;
+            let soup_status;
+            if ((obj.name === 'soup') && (terrain_type === 'P')) {
+                let ingredients = obj._ingredients.map(x => x['name']);
+
+                // select pot sprite
+                if (!obj.is_ready) {
+                    soup_status = "idle";
+                }
+                else {
+                    soup_status = "cooked";
+                }
+                spriteframe = this._ingredientsToSpriteFrame(ingredients, soup_status);
+                let objsprite = this.add.sprite(
+                    this.tileSize*x,
+                    this.tileSize*y,
+                    "soups",
+                    spriteframe
+                );
+                objsprite.setDisplaySize(this.tileSize, this.tileSize);
+                objsprite.depth = 1;
+                objsprite.setOrigin(0);
+                let objs_here = {objsprite};
+
+                // show time accordingly
+                let show_time = true;
+                if (obj._cooking_tick > obj.cook_time && !this.show_post_cook_time || obj._cooking_tick == -1) {
+                    show_time = false;
+                }
+                if (show_time) {
+                    let timesprite =  this.add.text(
+                        this.tileSize*(x+.5),
+                        this.tileSize*(y+.6),
+                        String(obj._cooking_tick),
+                        {
+                            font: "25px Arial",
+                            fill: "red",
+                            align: "center",
+                        }
+                    );
+                    timesprite.depth = 2;
+                    objs_here['timesprite'] = timesprite;
+                }
+
+                sprites['objects'][objpos] = objs_here
+            }
+            else if (obj.name === 'soup') {
+                let ingredients = obj._ingredients.map(x => x['name']);
+                let soup_status = "done";
+                spriteframe = this._ingredientsToSpriteFrame(ingredients, soup_status);
+                let objsprite = this.add.sprite(
+                    this.tileSize*x,
+                    this.tileSize*y,
+                    "soups",
+                    spriteframe
+                );
+                objsprite.setDisplaySize(this.tileSize, this.tileSize);
+                objsprite.depth = 1;
+                objsprite.setOrigin(0);
+                sprites['objects'][objpos] = {objsprite};
+            }
+            else {
+                if (obj.name === 'onion') {
+                    spriteframe = "onion.png";
+                }
+                else if (obj.name === 'tomato') {
+                    spriteframe = "tomato.png";
+                }
+                else if (obj.name === 'dish') {
+                    spriteframe = "dish.png";
+                }
+                let objsprite = this.add.sprite(
+                    this.tileSize*x,
+                    this.tileSize*y,
+                    "objects",
+                    spriteframe
+                );
+                objsprite.setDisplaySize(this.tileSize, this.tileSize);
+                objsprite.depth = 1;
+                objsprite.setOrigin(0);
+                sprites['objects'][objpos] = {objsprite};
+            }
+        }        
+    }
+
+    _drawHUD(hud_data, sprites, board_height) {
+        if (typeof(hud_data.all_orders) !== 'undefined') {
+            this._drawAllOrders(hud_data.all_orders, sprites, board_height);
+        }
+        if (typeof(hud_data.bonus_orders) !== 'undefined') {
+            this._drawBonusOrders(hud_data.bonus_orders, sprites, board_height);
+        }
+        if (typeof(hud_data.time) !== 'undefined') {
+            this._drawTimeLeft(hud_data.time, sprites, board_height);
+        }
+        if (typeof(hud_data.score) !== 'undefined') {
+            this._drawScore(hud_data.score, sprites, board_height);
+        }
+        if (typeof(hud_data.potential) !== 'undefined') {
+            this._drawPotential(hud_data.potential, sprites, board_height);
+        }
+    }
+
+    _drawBonusOrders(orders, sprites, board_height) {
+        if (typeof(orders) !== 'undefined' && orders !== null) {
+            let orders_str = "Bonus Orders: ";
+            if (typeof(sprites['bonus_orders']) !== 'undefined') {
+                // Clear existing orders
+                sprites['bonus_orders']['orders'].forEach(element => {
+                    element.destroy();
+                });
+                sprites['bonus_orders']['orders'] = [];
+
+                // Update with new orders
+                for (let i = 0; i < orders.length; i++) {
+                    let spriteFrame = this._ingredientsToSpriteFrame(orders[i]['ingredients'], "done");
+                    let orderSprite = this.add.sprite(
+                        130 + 40 * i,
+                        board_height + 40,
+                        "soups",
+                        spriteFrame
+                    );
+                    sprites['bonus_orders']['orders'].push(orderSprite);
+                    orderSprite.setDisplaySize(60, 60);
+                    orderSprite.setOrigin(0);
+                    orderSprite.depth = 1;
+                }
+            }
+            else {
+                sprites['bonus_orders'] = {};
+                sprites['bonus_orders']['str'] = this.add.text(
+                    5, board_height + 60, orders_str,
+                    {
+                        font: "20px Arial",
+                        fill: "red",
+                        align: "left"
+                    }
+                )
+                sprites['bonus_orders']['orders'] = []
+            }
+        }
+    }
+
+    _drawAllOrders(orders, sprites, board_height) {
+        if (typeof(orders) !== 'undefined' && orders !== null) {
+            let orders_str = "All Orders: ";
+            if (typeof(sprites['all_orders']) !== 'undefined') {
+                // Clear existing orders
+                sprites['all_orders']['orders'].forEach(element => {
+                    element.destroy();
+                });
+                sprites['all_orders']['orders'] = [];
+
+                // Update with new orders
+                for (let i = 0; i < orders.length; i++) {
+                    let spriteFrame = this._ingredientsToSpriteFrame(orders[i]['ingredients'], "done");
+                    let orderSprite = this.add.sprite(
+                        90 + 40 * i,
+                        board_height - 4,
+                        "soups",
+                        spriteFrame
+                    );
+                    sprites['all_orders']['orders'].push(orderSprite);
+                    orderSprite.setDisplaySize(60, 60);
+                    orderSprite.setOrigin(0);
+                    orderSprite.depth = 1;
+                }
+            }
+            else {
+                sprites['all_orders'] = {};
+                sprites['all_orders']['str'] = this.add.text(
+                    5, board_height + 15, orders_str,
+                    {
+                        font: "20px Arial",
+                        fill: "red",
+                        align: "left"
+                    }
+                )
+                sprites['all_orders']['orders'] = []
+            }
+        }
+    }
+
+    _drawScore(score, sprites, board_height) {
+        score = "Score: "+score;
+        if (typeof(sprites['score']) !== 'undefined') {
+            sprites['score'].setText(score);
+        }
+        else {
+            sprites['score'] = this.add.text(
+                5, board_height + 90, score,
+                {
+                    font: "20px Arial",
+                    fill: "red",
+                    align: "left"
+                }
+            )
+        }
+    }
+
+    _drawPotential(potential, sprites, board_height) {
+        potential = "Potential: "+potential;
+        if (typeof(sprites['potential']) !== 'undefined') {
+            sprites['potential'].setText(potential);
+        }
+        else {
+            sprites['potential'] = this.add.text(
+                100, board_height + 90, potential,
+                {
+                    font: "20px Arial",
+                    fill: "red",
+                    align: "left"
+                }
+            )
+        }
+    }
+
+    _drawTimeLeft(time_left, sprites, board_height) {
+        time_left = "Time Left: "+time_left;
+        if (typeof(sprites['time_left']) !== 'undefined') {
+            sprites['time_left'].setText(time_left);
+        }
+        else {
+            sprites['time_left'] = this.add.text(
+                5, board_height + 115, time_left,
+                {
+                    font: "20px Arial",
+                    fill: "red",
+                    align: "left"
+                }
+            )
+        }
+    }
+
+    _ingredientsToSpriteFrame(ingredients, status) {
+        let num_tomatoes = ingredients.filter(x => x === 'tomato').length;
+        let num_onions = ingredients.filter(x => x === 'onion').length;
+        return `soup_${status}_tomato_${num_tomatoes}_onion_${num_onions}.png`
+    }
+}
+

--- a/overcooked-demo/server/graphics/overcooked_graphics_v2.2.js
+++ b/overcooked-demo/server/graphics/overcooked_graphics_v2.2.js
@@ -351,7 +351,8 @@ class OvercookedScene extends Phaser.Scene {
         if (typeof(hud_data.score) !== 'undefined') {
             this._drawScore(hud_data.score, sprites, board_height);
         }
-        if (typeof(hud_data.potential) !== 'undefined') {
+        if (typeof(hud_data.potential) !== 'undefined' && hud_data.potential !== null) {
+            console.log(hud_data.potential)
             this._drawPotential(hud_data.potential, sprites, board_height);
         }
     }

--- a/overcooked-demo/server/requirements.txt
+++ b/overcooked-demo/server/requirements.txt
@@ -1,6 +1,7 @@
 certifi==2020.6.20
 click==7.1.2
 dnspython==1.16.0
+dill==0.3.2
 Flask==1.1.2
 Flask-SocketIO==4.3.0
 greenlet==0.4.16
@@ -12,3 +13,5 @@ python-engineio==3.13.0
 python-socketio==4.6.0
 six==1.15.0
 Werkzeug==1.0.1
+tensorflow==2.0.2
+requests==2.23.0

--- a/overcooked-demo/server/static/js/index.js
+++ b/overcooked-demo/server/static/js/index.js
@@ -38,6 +38,7 @@ $(function() {
  * * * * * * * * * * * * */
 
 window.intervalID = -1;
+window.spectating = true;
 
 socket.on('waiting', function(data) {
     // Show game lobby
@@ -70,8 +71,9 @@ socket.on('start_game', function(data) {
     }
     graphics_config = {
         container_id : "overcooked",
-        start_info : data
+        start_info : data.start_info
     };
+    window.spectating = data.spectating;
     $("#overcooked").empty();
     $('#game-over').hide();
     $('#lobby').hide();
@@ -80,13 +82,20 @@ socket.on('start_game', function(data) {
     $("#instructions").hide();
     $('#leave').show();
     $('#game-title').show();
-    enable_key_listener();
+    
+    if (!window.spectating) {
+        enable_key_listener();
+    }
+    
     graphics_start(graphics_config);
 });
 
 socket.on('reset_game', function(data) {
     graphics_end();
-    disable_key_listener();
+    if (!window.spectating) {
+        disable_key_listener();
+    }
+    
     $("#overcooked").empty();
     $("#reset-game").show();
     setTimeout(function() {
@@ -95,8 +104,10 @@ socket.on('reset_game', function(data) {
             container_id : "overcooked",
             start_info : data.state
         };
+        if (!window.spectating) {
+            enable_key_listener();
+        }
         graphics_start(graphics_config);
-        enable_key_listener();
     }, data.timeout);
 });
 
@@ -108,7 +119,9 @@ socket.on('state_pong', function(data) {
 socket.on('end_game', function(data) {
     // Hide game data and display game-over html
     graphics_end();
-    disable_key_listener();
+    if (!window.spectating) {
+        disable_key_listener();
+    }
     $('#game-title').hide();
     $('#game-over').show();
     $("#join").show();

--- a/overcooked-demo/server/static/js/index.js
+++ b/overcooked-demo/server/static/js/index.js
@@ -46,6 +46,7 @@ window.spectating = true;
 
 socket.on('waiting', function(data) {
     // Show game lobby
+    $('#waiting').hide();
     $('#game-over').hide();
     $('#instructions').hide();
     $("#overcooked").empty();

--- a/overcooked-demo/server/static/js/index.js
+++ b/overcooked-demo/server/static/js/index.js
@@ -64,6 +64,11 @@ socket.on('creation_failed', function(data) {
     // Tell user what went wrong
     let err = data['error']
     $("#overcooked").empty();
+    $('#lobby').hide();
+    $("#instructions").show();
+    $('#waiting').hide();
+    $('#join').show();
+    $('#create').show();
     $('#overcooked').append(`<h4>Sorry, game creation code failed with error: ${JSON.stringify(err)}</>`);
 });
 

--- a/overcooked-demo/server/static/js/index.js
+++ b/overcooked-demo/server/static/js/index.js
@@ -14,6 +14,10 @@ $(function() {
             "game_name" : "overcooked"
         };
         socket.emit("create", data);
+        $('#waiting').show();
+        $('#join').hide();
+        $('#create').hide();
+        $("#instructions").hide();
     });
 });
 
@@ -77,6 +81,7 @@ socket.on('start_game', function(data) {
     $("#overcooked").empty();
     $('#game-over').hide();
     $('#lobby').hide();
+    $('#waiting').hide();
     $('#join').hide();
     $('#create').hide();
     $("#instructions").hide();

--- a/overcooked-demo/server/static/js/psiturk.js
+++ b/overcooked-demo/server/static/js/psiturk.js
@@ -61,7 +61,7 @@ socket.on('start_game', function(data) {
     }
     graphics_config = {
         container_id : "overcooked",
-        start_info : data
+        start_info : data.start_info
     };
     $("#overcooked").empty();
     $('#game-over').hide();

--- a/overcooked-demo/server/static/js/tutorial.js
+++ b/overcooked-demo/server/static/js/tutorial.js
@@ -125,7 +125,7 @@ socket.on('start_game', function(data) {
     curr_tutorial_phase = 0;
     graphics_config = {
         container_id : "overcooked",
-        start_info : data
+        start_info : data.start_info
     };
     $("#overcooked").empty();
     $('#game-over').hide();

--- a/overcooked-demo/server/static/templates/index.html
+++ b/overcooked-demo/server/static/templates/index.html
@@ -59,6 +59,10 @@
     <label for="gameTime">Game Length (sec)</label>
     <input type="number" id="gameTime" value="30" min="1" max="1800" name="gameTime">
   </div>
+  <div class="form-group col-lg-2">
+    <label for="showPotential">Show Potential?</label>
+    <input type="checkbox" id="showPotential" name="showPotential">
+  </div>
   
       </div>
       </div>

--- a/overcooked-demo/server/static/templates/index.html
+++ b/overcooked-demo/server/static/templates/index.html
@@ -68,6 +68,9 @@
         <h4 class="text-center">Game Lobby</h4>
         Waiting for game to start...
     </div>
+    <div id="waiting", class="text-center" style="display:none">
+      Waiting for game to be created. Please be patient...
+    </div>
     <div id="overcooked-container" class="text-center">
         <h4 id="game-title" style="display:none">Game in Progress</h4>
         <h4 id="game-over" style="display:none">Game Over</h4>


### PR DESCRIPTION
## Zero Player Games
* Added ability to create and spectate AI-AI games
* Added support for loading rllib agents (this required adding human_aware_rl as a dependency in the docker build)


## Visualize Potential
* Ability for user to specify via checkbox whether the graphics should display the current state potential
* Super useful to me for debugging potential function
* Requires computing MLP when option is specified, which causes game creation to take ~1 minute when MLP has to be re-computed (not found in file)
* Added new html to indicate status of game loading
* Once new layouts are finalized we might want to add pickled planners for the new layouts to Overcooked_ai
* When "show potential" is not checked, the app avoids loading the MLP, which reduces load times back to order of 10ths of seconds

<img width="1216" alt="Screen Shot 2020-08-06 at 3 23 41 PM" src="https://user-images.githubusercontent.com/35500370/89579307-2c670900-d7f9-11ea-9d43-2f0f4f99fde7.png">
