### PR TITLE
adds integration with dynamic orders

### DIFF
--- a/server/game.py
+++ b/server/game.py
@@ -572,6 +572,12 @@ class OvercookedGame(Game):
         state_dict = {}
         state_dict['potential'] = self.phi if self.show_potential else None
         state_dict['state'] = self.state.to_dict()
+        if hasattr(self.state, "orders_list"):
+            if not hasattr(state_dict['state'], "all_orders"):
+                state_dict['state']["all_orders"] = [order.to_dict() for order in self.state.all_orders]
+            if not hasattr(state_dict['state'], "bonus_orders"):
+                state_dict['state']["bonus_orders"] = [order.to_dict() for order in self.state.bonus_orders]
+
         state_dict['score'] = self.score
         state_dict['time_left'] = max(self.max_time - (time() - self.start_time), 0)
         return state_dict


### PR DESCRIPTION
Allows to work with dynamic_orders change. Should be merged along with PR in overcooked_ai repo https://github.com/HumanCompatibleAI/overcooked_ai/pull/57 .
Fully backward compatible (works with https://github.com/HumanCompatibleAI/overcooked_ai/tree/master, works with https://github.com/bmielnicki/overcooked_ai/tree/dynamic_orders), unless you use layout that uses dynamic orders nothing really changes.

![backward_compatibility](https://user-images.githubusercontent.com/17073081/94083252-0f1ae800-fe03-11ea-8138-bf1878da61d0.png)

If you use dynamic orders timer for order is displayed below recipe icon. Colour indicates if order is bonus - yellow for ordinary order and green for bonus_order.

![new_view](https://user-images.githubusercontent.com/17073081/94083386-46899480-fe03-11ea-9143-9828aecb5364.png)

Except that I did minor cleaning in the code.
Code was tested by me using changes in Dockerfile to change overcooked_ai repos urls and by editing config to include dynamic orders layouts (this PR does not includes that changes).
Without adding dynamic orders layouts to config this PR does nothing from user perspective except it allows to work with dynamic orders PR (change in game.py allows that).