### PR TITLE
adds generated layouts

### DIFF
--- a/server/config.json
+++ b/server/config.json
@@ -1,6 +1,6 @@
 {
     "logfile" : "app.log",
-    "layouts" : ["cramped_room", "cramped_room_tomato", "asymmetric_advantages", "coordination_ring", "forced_coordination", "counter_circuit", "cramped_corridor", "marshmallow_experiment", "long_cook_time", "forced_coordination_tomato", "asymmetric_advantages_tomato", "marshmallow_experiment_coordination", "pipeline", "you_shall_not_pass", "tutorial_3"],
+    "layouts" : ["cramped_room", "cramped_room_tomato", "asymmetric_advantages", "coordination_ring", "forced_coordination", "counter_circuit", "cramped_corridor", "marshmallow_experiment", "long_cook_time", "forced_coordination_tomato", "asymmetric_advantages_tomato", "marshmallow_experiment_coordination", "pipeline", "you_shall_not_pass", "tutorial_3", "complicated_random_room", "simple_random_room"],
     "MAX_GAMES" : 10,
     "MAX_GAME_LENGTH" : 120,
     "AGENT_DIR" : "./static/assets/agents",


### PR DESCRIPTION
Adds the possibility to pick from layouts list "complicated_random_room" and "simple_random_room".
Now when loading layout it first check if there is a .json file with mdp_gen_params inside static/layout_generation_params and if it is found use it to generate layout. If there is no .json file it searches for .layout file like before.