### PR TITLE
named parameters in up.sh; saving trajectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ node_modules/
 **/master_agents/
 **/__pycache__/
 **/agents/
+**/trajectories/
+.env

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Building the server image requires [Docker](https://docs.docker.com/get-docker/)
 
 The server can be deployed locally using the driver script included in the repo. To run the production server, use the command
 ```bash
-./up.sh production
+./up.sh --env production
 ```
 
 In order to build and run the development server, which includes a deterministic scheduler and helpful debugging logs, run
@@ -40,28 +40,33 @@ In order to kill the production server, run
 
 The Overcooked-Demo server relies on both the [overcooked-ai](https://github.com/HumanCompatibleAI/overcooked_ai) and [human-aware-rl](https://github.com/HumanCompatibleAI/human_aware_rl) repos. The former contains the game logic, the latter contains the rl training code required for managing agents. Both repos are automatically cloned and installed in the Docker builds.
 
-The branch of `overcooked_ai` and `human_aware_rl` imported in both the development and production servers can be specified by the `OVERCOOKED_BRANCH` and `HARL_BRANCH` environment variables, respectively. For example, to use the branch `foo` from `overcooked-ai` and branch `bar` from `human_aware_rl`, run
+The branch of `overcooked_ai` and `human_aware_rl` imported in both the development and production servers can be specified by the `--overcooked-branch` and `--harl-branch` parameters, respectively. For example, to use the branch `foo` from `overcooked-ai` and branch `bar` from `human_aware_rl`, run
 ```bash
-OVERCOOKED_BRANCH=foo HARL_BRANCH=bar ./up.sh
+./up.sh --overcooked-branch foo --harl-branch bar
 ```
 The default branch for both repos is currently `master`.
 
 ## Using Pre-trained Agents
 
-Overcooked-Demo can dynamically load pre-trained agents provided by the user. In order to use a pre-trained agent, a pickle file should be added to the `agents` directory. The final structure will look like `static/assets/agents/<agent_name>/agent.pickle`. Note, to use the pre-defined rllib loading routine, the agent directory name must start with 'rllib', and contain the appropriate rllib checkpoint, config, and metadata files. For more detailed info and instructions see the [RllibDummy_CrampedRoom](server/static/assets/agents/RllibDummy_CrampedRoom/) example agent.
+Overcooked-Demo can dynamically load pre-trained agents provided by the user. In order to use a pre-trained agent, a pickle file should be added to the `agents` directory. The final structure will look like `static/assets/agents/<agent_name>/agent.pickle`. You can also specify other agent directory by using `--agents-dir` parameter.
+Note, to use the pre-defined rllib loading routine, the agent directory name must start with 'rllib', and contain the appropriate rllib checkpoint, config, and metadata files. For more detailed info and instructions see the [RllibDummy_CrampedRoom](server/static/assets/agents/RllibDummy_CrampedRoom/) example agent.
 
 If a more complex or custom loading routing is necessary, one can subclass the `OvercookedGame` class and override the `get_policy` method, as done in [DummyOvercookedGame](server/game.py#L420). Make sure the subclass is properly imported [here](server/app.py#L5)
 
+## Saving trajectories
+Trajectories from games run in overcooked-demo can be saved. By using `--trajectories-dir` you can specify directory that will be used to save trajectories. By default trajectories are saved inside `static/assets/trajectories` directory.
+
+
 ## Updating Overcooked_ai
-This repo was designed to be as flexible to changes in overcooked_ai as possible. To change the branch used, use the `OVERCOOKED_BRANCH` environment variable shown above.
+This repo was designed to be as flexible to changes in overcooked_ai as possible. To change the branch used, use the `--overcooked-branch` parameter shown above.
 
 Changes to the JSON state representation of the game will require updating the JS graphics. At the highest level, a graphics implementation must implement the functions `graphics_start`, called at the start of each game, `graphics_end`, called at the end of each game, and `drawState`, called at every timestep tick. See [dummy_graphcis.js](server/graphics/dummy_graphics.js) for a barebones example.
 
-The graphics file is dynamically loaded into the docker container and served to the client. Which file is loaded is determined by the `GRAPHICS` environment variable. For example, to server `dummy_graphics.js` one would run
+The graphics file is dynamically loaded into the docker container and served to the client. Which file is loaded is determined by the `--graphics` parameter. For example, to server `dummy_graphics.js` one would run
 ```bash
-GRAPHICS=dummy_graphics.js ./up.sh
+./up.sh --graphics dummy_graphics.js
 ```
-The default graphics file is currently `overcooked_graphics_v2.1.js`
+The default graphics file is currently `overcooked_graphics_v2.2.js`
 
 
 ## Configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version : '3.7'
 
 services:
     app:
+        env_file:
+        - .env
         build:
             context: ./server
             args:
@@ -13,4 +15,6 @@ services:
             FLASK_ENV: "${BUILD_ENV:-production}"
         ports:
             - "80:5000"
-        
+        volumes:
+            - "${AGENTS_DIR:-./server/static/assets/agents}:/app/static/assets/agents"
+            - "${TRAJECTORIES_DIR:-./server/static/assets/trajectories}:/app/static/assets/trajectories"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,10 +1,4 @@
 FROM python:3.7-stretch
-
-ARG BUILD_ENV
-ARG OVERCOOKED_BRANCH
-ARG HARL_BRANCH
-ARG GRAPHICS
-
 WORKDIR /app
 
 # Install non-chai dependencies
@@ -12,10 +6,13 @@ COPY ./requirements.txt ./requirements.txt
 RUN pip install -r requirements.txt
 
 # Install eventlet production server if production build
+ARG BUILD_ENV
 RUN if [ "$BUILD_ENV" = "production" ] ; then pip install eventlet ; fi
 
 # Clone chai code
+ARG OVERCOOKED_BRANCH
 RUN git clone https://github.com/HumanCompatibleAI/overcooked_ai.git --branch $OVERCOOKED_BRANCH --single-branch /overcooked_ai
+ARG HARL_BRANCH
 RUN git clone https://github.com/HumanCompatibleAI/human_aware_rl.git --branch $HARL_BRANCH --single-branch /human_aware_rl
 
 # Dummy data_dir so things don't break
@@ -31,6 +28,7 @@ RUN apt-get install -y libgl1-mesa-dev
 # Copy over remaining files
 COPY ./static ./static
 COPY ./*.py ./
+ARG GRAPHICS
 COPY ./graphics/$GRAPHICS ./static/js/graphics.js
 COPY ./config.json ./config.json
 

--- a/server/app.py
+++ b/server/app.py
@@ -14,7 +14,6 @@ from flask_socketio import SocketIO, join_room, leave_room, emit
 from game import OvercookedGame, OvercookedTutorial, Game, OvercookedPsiturk
 import game
 
-
 ### Thoughts -- where I'll log potential issues/ideas as they come up
 # Should make game driver code more error robust -- if overcooked randomlly errors we should catch it and report it to user
 # Right now, if one user 'join's before other user's 'join' finishes, they won't end up in same game
@@ -44,6 +43,8 @@ MAX_GAME_LENGTH = CONFIG['MAX_GAME_LENGTH']
 
 # Path to where pre-trained agents will be stored on server
 AGENT_DIR = CONFIG['AGENT_DIR']
+
+TRAJECTORIES_DIR = CONFIG["TRAJECTORIES_DIR"]
 
 # Maximum number of games that can run concurrently. Contrained by available memory and CPU
 MAX_GAMES = CONFIG['MAX_GAMES']
@@ -91,7 +92,7 @@ GAME_NAME_TO_CLS = {
     "psiturk" : OvercookedPsiturk
 }
 
-game._configure(MAX_GAME_LENGTH, AGENT_DIR)
+game._configure(MAX_GAME_LENGTH, AGENT_DIR, TRAJECTORIES_DIR)
 
 
 

--- a/server/config.json
+++ b/server/config.json
@@ -4,6 +4,7 @@
     "MAX_GAMES" : 10,
     "MAX_GAME_LENGTH" : 120,
     "AGENT_DIR" : "./static/assets/agents",
+    "TRAJECTORIES_DIR": "./static/assets/trajectories",
     "MAX_FPS" : 30,
     "psiturk" : {
         "experimentParams" : {

--- a/server/game.py
+++ b/server/game.py
@@ -6,20 +6,24 @@ from overcooked_ai_py.mdp.overcooked_mdp import OvercookedGridworld
 from overcooked_ai_py.mdp.overcooked_env import OvercookedEnv
 from overcooked_ai_py.mdp.actions import Action, Direction
 from overcooked_ai_py.planning.planners import MotionPlanner, NO_COUNTERS_PARAMS
+from overcooked_ai_py.agents.benchmarking import AgentEvaluator
 from human_aware_rl.rllib.rllib import load_agent
 import random, os, pickle, json
 import ray
+import numpy as np
 
 # Relative path to where all static pre-trained agents are stored on server
 AGENT_DIR = None
+TRAJECTORIES_DIR = None
 
 # Maximum allowable game time (in seconds)
 MAX_GAME_TIME = None
 
-def _configure(max_game_time, agent_dir):
-    global AGENT_DIR, MAX_GAME_TIME
+def _configure(max_game_time, agent_dir, trajectories_dir):
+    global AGENT_DIR, MAX_GAME_TIME, TRAJECTORIES_DIR
     MAX_GAME_TIME = max_game_time
     AGENT_DIR = agent_dir
+    TRAJECTORIES_DIR = trajectories_dir
 
 class Game(ABC):
 
@@ -381,13 +385,13 @@ class OvercookedGame(Game):
         - _curr_game_over: Determines whether the game on the current mdp has ended
     """
 
-    def __init__(self, layouts=["cramped_room"], mdp_params={}, num_players=2, gameTime=30, playerZero='human', playerOne='human', showPotential=False, randomized=False, **kwargs):
+    def __init__(self, layouts=["cramped_room"], mdp_params={}, num_players=2, gameTime=30, playerZero='human', playerOne='human', showPotential=False, randomized=False, saveTrajectory=False, **kwargs):
         super(OvercookedGame, self).__init__(**kwargs)
         self.show_potential = showPotential
         self.mdp_params = mdp_params
         self.layouts = layouts
         self.max_players = int(num_players)
-        self.mdp = None
+        self.env = None
         self.mp = None
         self.score = 0
         self.phi = 0
@@ -406,7 +410,7 @@ class OvercookedGame(Game):
         self.curr_tick = 0
         self.human_players = set()
         self.npc_players = set()
-
+        self.save_trajectory = bool(saveTrajectory)
         if randomized:
             random.shuffle(self.layouts)
 
@@ -421,7 +425,15 @@ class OvercookedGame(Game):
             self.add_player(player_one_id, idx=1, buff_size=1, is_human=False)
             self.npc_policies[player_one_id] = self.get_policy(playerOne, idx=1)
             self.npc_state_queues[player_one_id] = LifoQueue()
-        
+        self.trajectory = []
+
+    @property
+    def mdp(self):
+        return self.env.mdp
+
+    @property
+    def state(self):
+        return self.env.state
 
     def _curr_game_over(self):
         return time() - self.start_time >= self.max_time
@@ -479,7 +491,41 @@ class OvercookedGame(Game):
     def apply_action(self, player_id, action):
         pass
 
-    def apply_actions(self):
+    def _log_trajectory_step(self, state, joint_action, reward, done, info):
+        self.trajectory.append((state, tuple(joint_action), reward, done, info))
+
+    def _get_trajectory_dict(self):
+        trajectories = { k:[] for k in self.env.DEFAULT_TRAJ_KEYS }
+        trajectory = np.array(self.trajectory)
+        obs, actions, rews, dones, infos = trajectory.T[0], trajectory.T[1], trajectory.T[2], trajectory.T[3], trajectory.T[4]
+        trajectories["ep_states"].append(obs)
+        trajectories["ep_actions"].append(actions)
+        trajectories["ep_rewards"].append(rews)
+        trajectories["ep_dones"].append(dones)
+        trajectories["ep_infos"].append(infos)
+        trajectories["ep_returns"].append(self.score)
+        trajectories["ep_lengths"].append(self.env.state.timestep)
+        trajectories["mdp_params"].append(self.env.mdp.mdp_params)
+        trajectories["env_params"].append(self.env.env_params)
+        trajectories["metadatas"].append({})
+        trajectories = {k: np.array(v) for k, v in trajectories.items()}
+
+        AgentEvaluator.check_trajectories(trajectories)
+        return trajectories
+
+    def _create_trajectory_filename(self):
+        milis_timestamp = str(int(time()*1000))
+        return "trajectory-"+milis_timestamp + ".json"
+
+    def get_data(self):
+        if self.save_trajectory:
+            file_path = os.path.join(TRAJECTORIES_DIR, self._create_trajectory_filename())
+            traj_dict = self._get_trajectory_dict()
+            AgentEvaluator.save_traj_as_json(traj_dict, file_path)
+            self.trajectory = []
+        return super(OvercookedGame, self).get_data()
+
+    def apply_actions(self, log_trajectory=True):
         # Default joint action, as NPC policies and clients probably don't enqueue actions fast 
         # enough to produce one at every tick
         joint_action = [Action.STAY] * len(self.players)
@@ -490,10 +536,12 @@ class OvercookedGame(Game):
                 joint_action[i] = self.pending_actions[i].get(block=False)
             except Empty:
                 pass
-        
-        # Apply overcooked game logic to get state transition
-        prev_state = self.state
-        self.state, info = self.mdp.get_state_transition(prev_state, joint_action)
+
+        prev_state = self.env.state
+        new_state, reward, done, info = self.env.step(joint_action)
+        if log_trajectory:
+            self._log_trajectory_step(prev_state, joint_action, reward, done, info)
+
         if self.show_potential:
             self.phi = self.mdp.potential_function(prev_state, self.mp, gamma=0.99)
 
@@ -503,23 +551,21 @@ class OvercookedGame(Game):
                 self.npc_state_queues[npc_id].put(self.state, block=False)
 
         # Update score based on soup deliveries that might have occured
-        curr_reward = sum(info['sparse_reward_by_agent'])
+        curr_reward = sum(info['sparse_r_by_agent'])
         self.score += curr_reward
 
-        # Return about the current transition
         return prev_state, joint_action, info
-        
 
     def enqueue_action(self, player_id, action):
         overcooked_action = self.action_to_overcooked_action[action]
         super(OvercookedGame, self).enqueue_action(player_id, overcooked_action)
 
     def reset(self):
+        self.env.reset()
         status = super(OvercookedGame, self).reset()
         if status == self.Status.RESET:
             # Hacky way of making sure game timer doesn't "start" until after reset timeout has passed
             self.start_time += self.reset_timeout / 1000
-
 
     def tick(self):
         self.curr_tick += 1
@@ -533,10 +579,11 @@ class OvercookedGame(Game):
             raise ValueError("Inconsistent State")
 
         self.curr_layout = self.layouts.pop()
-        self.mdp = OvercookedGridworld.from_layout_name(self.curr_layout, **self.mdp_params)
+        mdp = OvercookedGridworld.from_layout_name(self.curr_layout, **self.mdp_params)
+        self.env = OvercookedEnv.from_mdp(mdp)
         if self.show_potential:
             self.mp = MotionPlanner.from_pickle_or_compute(self.mdp, counter_goals=NO_COUNTERS_PARAMS)
-        self.state = self.mdp.get_standard_start_state()
+
         if self.show_potential:
             self.phi = self.mdp.potential_function(self.state, self.mp, gamma=0.99)
         self.start_time = time()
@@ -559,10 +606,8 @@ class OvercookedGame(Game):
         # Wait for all background threads to exit
         for t in self.threads:
             t.join()
-
         # Clear all action queues
         self.clear_pending_actions()
-
 
     def get_state(self):
         state_dict = {}
@@ -617,9 +662,8 @@ class OvercookedPsiturk(OvercookedGame):
     """
 
     def __init__(self, *args, psiturk_uid='-1', **kwargs):
-        super(OvercookedPsiturk, self).__init__(*args, showPotential=False, **kwargs)
+        super(OvercookedPsiturk, self).__init__(*args, showPotential=False, saveTrajectory=False, **kwargs)
         self.psiturk_uid = psiturk_uid
-        self.trajectory = []
 
     def activate(self):
         """
@@ -628,17 +672,10 @@ class OvercookedPsiturk(OvercookedGame):
         super(OvercookedPsiturk, self).activate()
         self.trial_id = self.psiturk_uid + str(self.start_time)
 
-    def apply_actions(self):
-        """
-        Applies pending actions then logs transition data
-        """
-        # Apply MDP logic
-        prev_state, joint_action, info = super(OvercookedPsiturk, self).apply_actions()
-
-        # Log data to send to psiturk client
-        curr_reward = sum(info['sparse_reward_by_agent'])
+    def _log_trajectory_step(self, state, joint_action, reward, done, info):
+        curr_reward = sum(info['sparse_r_by_agent'])
         transition = {
-            "state" : json.dumps(prev_state.to_dict()),
+            "state" : json.dumps(state.to_dict()),
             "joint_action" : json.dumps(joint_action),
             "reward" : curr_reward,
             "time_left" : max(self.max_time - (time() - self.start_time), 0),
@@ -653,7 +690,6 @@ class OvercookedPsiturk(OvercookedGame):
             "player_0_is_human" : self.players[0] in self.human_players,
             "player_1_is_human" : self.players[1] in self.human_players
         }
-
         self.trajectory.append(transition)
 
     def get_data(self):
@@ -677,7 +713,7 @@ class OvercookedTutorial(OvercookedGame):
     
 
     def __init__(self, layouts=["tutorial_0"], mdp_params={}, playerZero='human', playerOne='AI', phaseTwoScore=15, **kwargs):
-        super(OvercookedTutorial, self).__init__(layouts=layouts, mdp_params=mdp_params, playerZero=playerZero, playerOne=playerOne, showPotential=False, **kwargs)
+        super(OvercookedTutorial, self).__init__(layouts=layouts, mdp_params=mdp_params, playerZero=playerZero, playerOne=playerOne, showPotential=False, saveTrajectory=False, **kwargs)
         self.phase_two_score = phaseTwoScore
         self.phase_two_finished = False
         self.max_time = 0

--- a/server/static/templates/index.html
+++ b/server/static/templates/index.html
@@ -59,11 +59,14 @@
     <label for="gameTime">Game Length (sec)</label>
     <input type="number" id="gameTime" value="30" min="1" max="1800" name="gameTime">
   </div>
-  <div class="form-group col-lg-2">
+  <div class="form-group col-lg-1">
     <label for="showPotential">Show Potential?</label>
     <input type="checkbox" id="showPotential" name="showPotential">
   </div>
-  
+  <div class="form-group col-lg-1">
+    <label for="saveTrajectory">Save Trajectory?</label>
+    <input type="checkbox" id="saveTrajectory" name="saveTrajectory">
+  </div>
       </div>
       </div>
     </form>

--- a/up.sh
+++ b/up.sh
@@ -1,14 +1,75 @@
-if [[ $1 = prod* ]];
+# default arg values
+BUILD_ENV="development"
+
+# saved as .env file for docker-compose
+ENV_FILE=""
+
+# parse kwargs
+# for this and other ways check out https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash
+while [[ $# -gt 0 ]]
+do
+key="$1"
+case $key in
+    --build-env|--env)
+        if [[ "$2" = prod* ]];
+        then
+            BUILD_ENV="production"
+        fi
+        if [[ "$2" = dev* ]];
+        then
+            BUILD_ENV="development"
+        fi
+        shift # past argument
+        shift # past value
+        ;;
+    --branch|--overcooked-branch)
+        ENV_FILE+="OVERCOOKED_BRANCH=$2
+"
+        shift # past argument
+        shift # past value
+        ;;
+    --harl-branch)
+        ENV_FILE+="HARL_BRANCH=$2
+"
+        shift # past argument
+        shift # past value
+        ;;
+    --graphics)
+        ENV_FILE+="GRAPHICS=$2
+"
+        shift # past argument
+        shift # past value
+        ;;
+    --agents-dir)
+        ENV_FILE+="AGENTS_DIR=$2
+"
+        shift # past argument
+        shift # past value
+        ;;
+    --trajectories-dir|--trajs-dir)
+        ENV_FILE+="TRAJECTORIES_DIR=$2
+"
+        shift # past argument
+        shift # past value
+        ;;
+    *)    # unknown option
+    shift # past argument
+;;
+esac
+done
+
+ENV_FILE+="BUILD_ENV=$BUILD_ENV"
+echo "$ENV_FILE" > .env
+
+
+if [[ "$BUILD_ENV" = "production" ]] ;
 then
     echo "production"
-    export BUILD_ENV=production
-
     # Completely re-build all images from scatch without using build cache
     docker-compose build --no-cache
     docker-compose up --force-recreate -d
 else
     echo "development"
-    export BUILD_ENV=development
     # Uncomment the following line if there has been an updated to overcooked-ai code
     # docker-compose build --no-cache
 


### PR DESCRIPTION

1. Added usage of named parameters to up.sh. They can be used everything that was specified by env variables (that are no longer used), also trajectories and agents directories.
2. Pass to docker-compose all env variables by .env file. This prevents any naming collisions with other applications.
3. Trajectory and agent directories are now passed as volumes so all changes there (like saving trajectory) are now kept between sessions.
4. Added saving trajectories to trajectory directory. It uses OvercookedEnv so there is no code duplication between overcooked-demo and overcooked_ai code. Checkbox in index.html is added so user can choose if trajectory should be saved.
![save_trajectory](https://user-images.githubusercontent.com/17073081/95344035-7a5fc200-08b9-11eb-94a6-928e21917585.png)
5. Small changes in OvercookedPsiturk to work with changes in OvercookedGame.

I plan to add additional stuff into this branch (like replaying trajectories from trajectory directory), but changes above seems to be mergable into master now.